### PR TITLE
Patch to deal with named_route name collisions...

### DIFF
--- a/lib/ardes/resources_controller.rb
+++ b/lib/ardes/resources_controller.rb
@@ -849,7 +849,7 @@ end_str
       def raise_resource_mismatch(controller) #:nodoc:
         raise ResourceMismatch, <<-end_str
 resources_controller can't match the route to the resource specification
-  path:         #{controller.send(:request_path)}
+  path:         #{controller.send(:path_of_request)}
   specification: enclosing: [#{controller.specifications.collect{|s| s.is_a?(Specification) ? ":#{s.segment}" : s}.join(', ')}], resource :#{controller.resource_specification.segment}
   
 the successfully loaded enclosing resources are: #{controller.enclosing_resources.join(', ')}

--- a/lib/ardes/resources_controller/request_path_introspection.rb
+++ b/lib/ardes/resources_controller/request_path_introspection.rb
@@ -6,17 +6,17 @@ module Ardes
     # these methods are aware of resource specifications specified either by map_enclosing_resource.
     module RequestPathIntrospection
     protected
-      def request_path
-        @request_path ||= params[:resource_path] || request.path
+      def path_of_request
+        @path_of_request ||= params[:resource_path] || request.path
       end
       
-      def nesting_request_path
-        @nesting_request_path ||= remove_namespace(remove_current_segment(request_path))
+      def nesting_path_of_request
+        @nesting_path_of_request ||= remove_namespace(remove_current_segment(path_of_request))
       end
       
       # returns an array of hashes like {:segment => 'forum', :singleton => false}
       def nesting_segments
-        @nesting_segments ||= segments_for_path_and_keys(nesting_request_path, param_keys)
+        @nesting_segments ||= segments_for_path_and_keys(nesting_path_of_request, param_keys)
       end
       
       # returns an array of segments correspopnding to the namespace of the controller.
@@ -25,7 +25,7 @@ module Ardes
       def namespace_segments
         unless @namespace_segments
           namespace = controller_path.sub(%r(#{controller_name}$), '')
-          @namespace_segments = (request_path =~ %r(^/#{namespace}) ? namespace.split('/') : [])
+          @namespace_segments = (path_of_request =~ %r(^/#{namespace}) ? namespace.split('/') : [])
         end
         @namespace_segments
       end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -9,7 +9,7 @@ describe TagsController do
       @tag.stub!(:to_param).and_return('2')
       Tag.stub!(:find).and_return(@tag)
     
-      @controller.stub!(:request_path).and_return('/tags/2')
+      @controller.stub!(:path_of_request).and_return('/tags/2')
       get :show, :id => "2"
     end
   
@@ -67,7 +67,7 @@ describe TagsController do
     end
   
     def do_get
-      @controller.stub!(:request_path).and_return('/tags/index')
+      @controller.stub!(:path_of_request).and_return('/tags/index')
       get :index
     end
 

--- a/spec/controllers/tags_controller_via_account_info_spec.rb
+++ b/spec/controllers/tags_controller_via_account_info_spec.rb
@@ -25,7 +25,7 @@ describe TagsController do
       @tag.stub!(:to_param).and_return('2')
       @info_tags.stub!(:find).and_return(@tag)
     
-      @controller.stub!(:request_path).and_return('/account/info/tags/2')
+      @controller.stub!(:path_of_request).and_return('/account/info/tags/2')
       get :show, :id => 2
     end
   
@@ -68,7 +68,7 @@ describe TagsController do
       @other_tag = Tag.create
     
       @controller.instance_variable_set('@current_user', @account)
-      @controller.stub!(:request_path).and_return('/account/info/tags')
+      @controller.stub!(:path_of_request).and_return('/account/info/tags')
       get :index
       @resource_service = controller.send :resource_service
     end
@@ -105,7 +105,7 @@ describe TagsController do
     end
   
     def do_get
-      @controller.stub!(:request_path).and_return('/account/info/tags')
+      @controller.stub!(:path_of_request).and_return('/account/info/tags')
       get :index
     end
 

--- a/spec/controllers/tags_controller_via_forum_post_spec.rb
+++ b/spec/controllers/tags_controller_via_forum_post_spec.rb
@@ -27,7 +27,7 @@ describe TagsController do
       @tag.stub!(:to_param).and_return('3')
       @post_tags.stub!(:find).and_return(@tag)
     
-      @controller.stub!(:request_path).and_return('/forums/1/posts/1/tags/3')
+      @controller.stub!(:path_of_request).and_return('/forums/1/posts/1/tags/3')
       get :show, :forum_id => "1", :post_id => "2", :id => "3"
     end
   
@@ -69,7 +69,7 @@ describe TagsController do
       @other_post  = Post.create :forum_id => @forum.id
       @other_tag   = Tag.create :taggable_id => @other_post.id, :taggable_type => 'Post'
     
-      @controller.stub!(:request_path).and_return("/forums/:id/posts/:id/tags")
+      @controller.stub!(:path_of_request).and_return("/forums/:id/posts/:id/tags")
       get :index, :forum_id => @forum.id, :post_id => @post.id
       @resource_service = controller.send :resource_service
     end
@@ -106,7 +106,7 @@ describe TagsController do
     end
   
     def do_get
-      @controller.stub!(:request_path).and_return("/forums/1/posts/2/tags")
+      @controller.stub!(:path_of_request).and_return("/forums/1/posts/2/tags")
       get :index, :forum_id => '1', :post_id => '2'
     end
 

--- a/spec/lib/load_enclosing_resources_spec.rb
+++ b/spec/lib/load_enclosing_resources_spec.rb
@@ -11,7 +11,7 @@ module LoadEnclosingResourcesSpecHelper
 
   def setup_common
     @controller = @klass.new
-    @controller.stub!(:request_path).and_return('')
+    @controller.stub!(:path_of_request).and_return('')
     # stub :load_enclosing_resource_from_specification, increase enclosing_resources by one, and return a mock resource
     @controller.stub!(:load_enclosing_resource_from_specification).and_return do |name, _|
       mock("resource: #{name}").tap do |resource|

--- a/spec/lib/request_path_introspection_spec.rb
+++ b/spec/lib/request_path_introspection_spec.rb
@@ -15,61 +15,61 @@ module RequestPathIntrospectionSpec
       @controller.stub!(:request).and_return(mock('request', :path => '/forums'))
     end
     
-    describe "#request_path" do
+    describe "#path_of_request" do
       it "should default to request.path" do
-        @controller.send(:request_path).should == '/forums'
+        @controller.send(:path_of_request).should == '/forums'
       end
       
       it " should be params[:resource_path], when set" do
         @controller.params[:resource_path] = '/foo'
-        @controller.send(:request_path).should == '/foo'
+        @controller.send(:path_of_request).should == '/foo'
       end
     end
     
-    describe "#nesting_request_path" do
+    describe "#nesting_path_of_request" do
       it "should remove the controller_name segment" do
-        @controller.stub!(:request_path).and_return('/users/1/forums/2')
-        @controller.send(:nesting_request_path).should == '/users/1'
+        @controller.stub!(:path_of_request).and_return('/users/1/forums/2')
+        @controller.send(:nesting_path_of_request).should == '/users/1'
       end
       
       it "when resource_specification present, whould remove taht segment" do
         @controller.stub!(:resource_specification).and_return(Ardes::ResourcesController::Specification.new(:forum, :class => RequestPathIntrospectionSpec::Forum, :segment => 'foromas'))
-        @controller.stub!(:request_path).and_return('/users/1/foromas/2')
-        @controller.send(:nesting_request_path).should == '/users/1'
+        @controller.stub!(:path_of_request).and_return('/users/1/foromas/2')
+        @controller.send(:nesting_path_of_request).should == '/users/1'
       end
       
       it "should remove only the controller_name segment, when nesting is same name" do
-        @controller.stub!(:request_path).and_return('/forums/1/forums/2')
-        @controller.send(:nesting_request_path).should == '/forums/1'
+        @controller.stub!(:path_of_request).and_return('/forums/1/forums/2')
+        @controller.send(:nesting_path_of_request).should == '/forums/1'
       end
 
       it "should remove the controller_name segment, even when id matches controller name" do
-        @controller.stub!(:request_path).and_return('/forums/1/forums/forums.atom')
-        @controller.send(:nesting_request_path).should == '/forums/1'
+        @controller.stub!(:path_of_request).and_return('/forums/1/forums/forums.atom')
+        @controller.send(:nesting_path_of_request).should == '/forums/1'
       end
 
       it "should remove only the controller_name segment even when nesting is same name" do
         @controller.stub!(:resource_specification).and_return(Ardes::ResourcesController::Specification.new(:forum, :class => RequestPathIntrospectionSpec::Forum, :singleton => true))
-        @controller.stub!(:request_path).and_return('/users/1/forum/forum.atom')
-        @controller.send(:nesting_request_path).should == '/users/1/forum'
+        @controller.stub!(:path_of_request).and_return('/users/1/forum/forum.atom')
+        @controller.send(:nesting_path_of_request).should == '/users/1/forum'
       end
       
       it "should remove any controller namespace" do
         @controller.stub!(:controller_path).and_return('some/name/space/forums')
-        @controller.stub!(:request_path).and_return('/some/name/space/users/1/secret/forums')
-        @controller.send(:nesting_request_path).should == '/users/1/secret'
+        @controller.stub!(:path_of_request).and_return('/some/name/space/users/1/secret/forums')
+        @controller.send(:nesting_path_of_request).should == '/users/1/secret'
       end
     end
     
-    it "#namespace_segments should return [] segments if NOT present in request_path" do
+    it "#namespace_segments should return [] segments if NOT present in path_of_request" do
       @controller.stub!(:controller_path).and_return('some/name/space/forums')
-      @controller.stub!(:request_path).and_return('/SAM/name/space/users/1/secret/forums')
+      @controller.stub!(:path_of_request).and_return('/SAM/name/space/users/1/secret/forums')
       @controller.send(:namespace_segments).should == []
     end
     
-    it "#namespace_segments should return namespace segments if present in request_path" do
+    it "#namespace_segments should return namespace segments if present in path_of_request" do
       @controller.stub!(:controller_path).and_return('some/name/space/forums')
-      @controller.stub!(:request_path).and_return('/some/name/space/users/1/secret/forums')
+      @controller.stub!(:path_of_request).and_return('/some/name/space/users/1/secret/forums')
       @controller.send(:namespace_segments).should == ['some', 'name', 'space']
     end
     

--- a/spec/lib/resources_controller_spec.rb
+++ b/spec/lib/resources_controller_spec.rb
@@ -22,7 +22,7 @@ describe "ResourcesController#enclosing_resource_name" do
     @controller = TagsController.new
     info = mock_model(Info, :tags => [])
     @controller.stub!(:current_user).and_return(mock_model(User, :info => info))
-    @controller.stub!(:request_path).and_return('/account/info/tags')
+    @controller.stub!(:path_of_request).and_return('/account/info/tags')
     @controller.stub!(:params).and_return({})
     @controller.send :load_enclosing_resources
   end


### PR DESCRIPTION
Updating my app, I discovered that 'map.resources :requests' breaks recent
versions of resources_controller --- this defines a 'request_path' named route,
which in turn winds up clobbering resources_controller's internal method by
that name.

This is a patch to deal with the issue, by renaming the method to
'path_of_request', which takes it out of the line of fire.  Most of it is
updating the specs (which all still pass... at least after a 'mkdir tmp'
so it could create the sqlite3 test db).

FWIW, this is currently lighthouse ticket #9:

http://ianwhite.lighthouseapp.com/projects/10598/tickets/9-request_path-method-gets-clobbered-by-named-routes
