### PR TITLE
Stop modifying resource_specification_map in place

### DIFF
--- a/lib/resources_controller.rb
+++ b/lib/resources_controller.rb
@@ -489,7 +489,7 @@ module ResourcesController
   # See Specification#new for details of how to call this
   def map_enclosing_resource(name, options = {}, &block)
     spec = Specification.new(name, options, &block)
-    resource_specification_map[spec.segment] = spec
+    self.resource_specification_map = resource_specification_map.merge spec.segment => spec
   end
   
   # this will be deprecated soon as it's badly named - use map_enclosing_resource


### PR DESCRIPTION
Because this is a class attribute and modifying it in place will change the map for ALL
controllers not just the one you call map_enclosing_resource in.

This bug was introduced in commit 292c96986f1da6803b2826354d488eeb269da4d5
