### PR TITLE
Handle instance_methods containing Symbols in Ruby >= 1.9

### DIFF
--- a/lib/resources_controller/include_actions.rb
+++ b/lib/resources_controller/include_actions.rb
@@ -26,9 +26,10 @@ module ResourcesController
     
     def action_methods_to_remove(options = {})
       if options[:only]
-        instance_methods - Array(options[:only]).map(&:to_s)
+        # instance_methods contains Strings in < 1.9, and Symbols in >= 1.9
+        instance_methods.map(&:to_s) - Array(options[:only]).map(&:to_s)
       elsif options[:except]
-        Array(options[:except]).map(&:to_s) & instance_methods
+        Array(options[:except]).map(&:to_s) & instance_methods.map(&:to_s)
       else
         []
       end


### PR DESCRIPTION
This is necessary as `Module.instance_methods` contains [Strings in < 1.9](http://ruby-doc.org/core-1.8.7/Module.html#method-i-instance_methods), and [Symbols in >= 1.9](http://ruby-doc.org/core-1.9.3/Module.html#method-i-instance_methods)
