### PR TITLE
Better interaction with strong parameters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec

--- a/lib/resources_controller/actions.rb
+++ b/lib/resources_controller/actions.rb
@@ -121,16 +121,4 @@ module ResourcesController
     end
   end
 
-
-  # Never trust parameters from the scary internet, only allow the white list through.
-  def resource_params
-    if defined?(super)
-      return super
-    elsif self.respond_to?("#{resource_name}_params", true)
-      return self.send("#{resource_name}_params")
-    else
-      raise RuntimeError, "resource_params and #{resource_name}_params both unimplemented"
-    end
-  end
-  
 end

--- a/lib/resources_controller/actions.rb
+++ b/lib/resources_controller/actions.rb
@@ -129,7 +129,7 @@ module ResourcesController
     elsif self.respond_to?("#{resource_name}_params", true)
       return self.send("#{resource_name}_params")
     else
-      return params.require(resource_name).permit( *(resource_service.content_columns.map(&:name) - [ 'updated_at', 'created_at' ]) )
+      raise RuntimeError, "resource_params and #{resource_name}_params both unimplemented"
     end
   end
   

--- a/lib/resources_controller/actions.rb
+++ b/lib/resources_controller/actions.rb
@@ -124,7 +124,9 @@ module ResourcesController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def resource_params
-    if self.respond_to?("#{resource_name}_params", true)
+    if defined?(super)
+      return super
+    elsif self.respond_to?("#{resource_name}_params", true)
       return self.send("#{resource_name}_params")
     else
       return params.require(resource_name).permit( *(resource_service.content_columns.map(&:name) - [ 'updated_at', 'created_at' ]) )

--- a/lib/resources_controller/resource_methods.rb
+++ b/lib/resources_controller/resource_methods.rb
@@ -31,10 +31,10 @@ module ResourcesController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def resource_params
-      if defined?(super)
-        return super
-      elsif self.respond_to?("#{resource_name}_params", true)
+      if self.respond_to?("#{resource_name}_params", true)
         return self.send("#{resource_name}_params")
+      elsif defined?(super)
+        return super
       else
         raise NoMethodError, "resource_params and #{resource_name}_params both unimplemented"
       end

--- a/lib/resources_controller/resource_methods.rb
+++ b/lib/resources_controller/resource_methods.rb
@@ -13,12 +13,11 @@ module ResourcesController
       resource_service.find id
     end
 
-    # makes a new resource, if attributes are not supplied, determine them from the
-    # params hash and the current resource_class, or resource_name (the latter left in for BC)
+    # makes a new resource.  If attributes are not supplied, we try to get them
+    # from 'resource_params', if available.
     def new_resource(attributes = nil, &block)
-      if attributes.blank? && respond_to?(:params) && params.is_a?(ActionController::Parameters)
-        resource_form_name = ActiveModel::Naming.singular(resource_class)
-        attributes = params[resource_form_name] || params[resource_name] || {}
+      if attributes.blank? && respond_to?(:resource_params)
+        attributes = resource_params
       end
       resource_service.new attributes, &block
     end
@@ -37,7 +36,7 @@ module ResourcesController
       elsif self.respond_to?("#{resource_name}_params", true)
         return self.send("#{resource_name}_params")
       else
-        return params.fetch(resource_name, {}).permit( *(resource_service.content_columns.map(&:name) - [ 'updated_at', 'created_at' ]) )
+        raise RuntimeError, "resource_params and #{resource_name}_params both unimplemented"
       end
     end
   

--- a/lib/resources_controller/resource_methods.rb
+++ b/lib/resources_controller/resource_methods.rb
@@ -36,7 +36,7 @@ module ResourcesController
       elsif self.respond_to?("#{resource_name}_params", true)
         return self.send("#{resource_name}_params")
       else
-        raise RuntimeError, "resource_params and #{resource_name}_params both unimplemented"
+        raise NoMethodError, "resource_params and #{resource_name}_params both unimplemented"
       end
     end
   

--- a/lib/resources_controller/resource_methods.rb
+++ b/lib/resources_controller/resource_methods.rb
@@ -32,7 +32,9 @@ module ResourcesController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def resource_params
-      if self.respond_to?("#{resource_name}_params", true)
+      if defined?(super)
+        return super
+      elsif self.respond_to?("#{resource_name}_params", true)
         return self.send("#{resource_name}_params")
       else
         return params.fetch(resource_name, {}).permit( *(resource_service.content_columns.map(&:name) - [ 'updated_at', 'created_at' ]) )

--- a/spec/app.rb
+++ b/spec/app.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Testing app setup
 
 module ResourcesControllerTest
@@ -199,10 +200,6 @@ class ApplicationController < ActionController::Base
 protected
   def current_user
     @current_user
-  end
-
-  def resource_params
-    params
   end
 end
 

--- a/spec/app.rb
+++ b/spec/app.rb
@@ -96,6 +96,7 @@ ActiveRecord::Migration.suppress_messages do
 
     create_table :infos, :force => true do |t|
       t.column "user_id", :integer
+      t.column "info", :string
     end
 
     create_table :addresses, :force => true do |t|
@@ -206,7 +207,9 @@ end
 module Admin
   class ForumsController < ApplicationController
     resources_controller_for :forums
-
+    def resource_params
+      params['forum'].try(:permit, %i(owner_id))
+    end
   end
 
   class InterestsController < ApplicationController
@@ -235,10 +238,16 @@ end
 
 class InfosController < ApplicationController
   resources_controller_for :info, :singleton => true, :only => [:show, :edit, :update]
+  def resource_params
+    params['info'].try(:permit, %i(attr other_attr)) # no real attrs!
+  end
 end
 
 class TagsController < ApplicationController
   resources_controller_for :tags
+  def resource_params
+    params['tag'].try(:permit, :name)
+  end
 end
 
 class UsersController < ApplicationController

--- a/spec/controllers/admin_forums_controller_spec.rb
+++ b/spec/controllers/admin_forums_controller_spec.rb
@@ -433,11 +433,11 @@ end_str
     end
   
     def do_post
-      post :create, params: { :forum => {:name => 'Forum'} }
+      post :create, params: { :forum => {:owner_id => '1'} }
     end
   
     it "should create a new forum" do
-      expect(Forum).to receive(:new).with({'name' => 'Forum'}).and_return(@mock_forum)
+      expect(Forum).to receive(:new).with(ac_permitted(:owner_id => '1')).and_return(@mock_forum)
       do_post
     end
 
@@ -463,11 +463,11 @@ end_str
     end
   
     def do_post
-      post :create, params: { :forum => {:name => 'Forum'} }, xhr: true
+      post :create, params: { :forum => {:owner_id => '1'} }, xhr: true
     end
   
     it "should create a new forum" do
-      expect(Forum).to receive(:new).with({'name' => 'Forum'}).and_return(@mock_forum)
+      expect(Forum).to receive(:new).with(ac_permitted(:owner_id => '1')).and_return(@mock_forum)
       do_post
     end
 
@@ -492,12 +492,13 @@ end_str
 
     before(:each) do
       @mock_forum = double('Forum').as_null_object
+      @update_params = { :owner_id => "1" }
       allow(@mock_forum).to receive(:to_param).and_return("1")
       allow(Forum).to receive(:find).and_return(@mock_forum)
     end
   
     def do_update
-      put :update, params: { :id => "1" }
+      put :update, params: { :id => "1", :forum => @update_params }
     end
   
     it "should find the forum requested" do
@@ -511,7 +512,9 @@ end_str
     end
 
     it "should update the found forum" do
-      expect(@mock_forum).to receive(:update).and_return(true)
+      expected_params = ActionController::Parameters.new(@update_params)
+      expected_params.permit(:owner_id)
+      expect(@mock_forum).to receive(:update).with(expected_params).and_return(true)
       do_update
       expect(assigns(:forum)).to eq(@mock_forum)
     end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -298,11 +298,11 @@ describe CommentsController do
     end
   
     def do_post
-      post :create, params: { :comment => {:name => 'Comment'}, :forum_id => '3', :post_id => '2' }
+      post :create, params: { :comment => {:user_id => '3'}, :forum_id => '3', :post_id => '2' }
     end
   
     it "should build a new comment" do
-      expect(@post_comments).to receive(:build).with({'name' => 'Comment'}).and_return(@comment)
+      expect(@post_comments).to receive(:build).with(ac_permitted('user_id' => '3')).and_return(@comment)
       do_post
     end
 

--- a/spec/controllers/forums_controller_spec.rb
+++ b/spec/controllers/forums_controller_spec.rb
@@ -204,12 +204,12 @@ end_str
     end
   
     def do_post
-      post :create, params: { :forum => {:name => 'Forum'}, :resource_path => '/forums', :resource_method => :post }
+      post :create, params: { :forum => {:title => 'Forum'}, :resource_path => '/forums', :resource_method => :post }
     
     end
   
     it "should create a new forum" do
-      expect(Forum).to receive(:new).with({'name' => 'Forum'}).and_return(@mock_forum)
+      expect(Forum).to receive(:new).with(ac_permitted('title' => 'Forum')).and_return(@mock_forum)
       do_post
     end
 
@@ -490,11 +490,11 @@ end_str
     end
   
     def do_post
-      post :create, params: { :forum => {:name => 'Forum'} }
+      post :create, params: { :forum => {:title => 'Forum'} }
     end
   
     it "should create a new forum" do
-      expect(Forum).to receive(:new).with({'name' => 'Forum'}).and_return(@mock_forum)
+      expect(Forum).to receive(:new).with(ac_permitted('title' => 'Forum')).and_return(@mock_forum)
       do_post
     end
 
@@ -520,11 +520,11 @@ end_str
     end
   
     def do_post
-      post :create, params: { :forum => {:name => 'Forum'} }, xhr: true
+      post :create, params: { :forum => {:title => 'Forum'} }, xhr: true
     end
   
     it "should create a new forum" do
-      expect(Forum).to receive(:new).with({'name' => 'Forum'}).and_return(@mock_forum)
+      expect(Forum).to receive(:new).with(ac_permitted('title' => 'Forum')).and_return(@mock_forum)
       do_post
     end
 

--- a/spec/controllers/tags_controller_via_forum_spec.rb
+++ b/spec/controllers/tags_controller_via_forum_spec.rb
@@ -151,7 +151,7 @@ describe TagsController do
     end
   
     it "should build a new tag with params" do
-      expect(@forum_tags).to receive(:build).with("name" => "hello").and_return(@tag)
+      expect(@forum_tags).to receive(:build).with(ac_permitted("name" => "hello")).and_return(@tag)
       do_get
     end
   

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,11 +9,18 @@ require File.expand_path('../../lib/resources_controller', __FILE__)
 # just about every test fail.
 ActionController::Base.view_paths = [File.join(File.dirname(__FILE__), "app/views")]
 
+module SpecConveniences
+  def ac_permitted(hsh)
+    ActionController::Parameters.new(hsh).permit!
+  end
+end
+
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.use_instantiated_fixtures  = false
   config.infer_spec_type_from_file_location!
   config.expect_with(:rspec) { |c| c.syntax = [ :should, :expect ] }
+  config.include SpecConveniences # defined above
 end
 
 require 'rails-controller-testing'


### PR DESCRIPTION
This pull request deals with #14 by eliminating the default behavior of synthesizing a whitelist (which likely includes attributes that a client isn't meant to be able to set directly, including foreign keys and sensitive stuff like `is_admin` on a `User` object).  It also updates the docs to describe usage with strong parameters (in Rails 4+, or Rails 3 with the `strong_parameters` gem.

See discussion on the ticket for more particulars...